### PR TITLE
added getting collaborations

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -25,6 +25,7 @@ type Service interface {
 	GetStoryCollaborators(id primitive.ObjectID) ([]data.Collaborator, error)
 	GetStoriesByFilters(genre string, page, limit int) ([]data.StoryDetails, error)
 	GetStoriesByUser(userID primitive.ObjectID, page, limit int) ([]data.StoryDetails, error)
+	GetCollaborations(userID primitive.ObjectID, page, limit int) ([]data.StoryDetails, error)
 	ValidateToken(authHeader string) (primitive.ObjectID, error)
 	Health() (map[string]string, error)
 }
@@ -178,6 +179,29 @@ func (s *service) GetStoriesByUser(userID primitive.ObjectID, page, limit int) (
 	if err := cursor.All(ctx, &stories); err != nil {
 		return nil, fmt.Errorf("error decoding stories: %v", err)
 	}
+	return stories, nil
+}
+
+func (s *service) GetCollaborations(userID primitive.ObjectID, page, limit int) ([]data.StoryDetails, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	skip := (page - 1) * limit
+	findOptions := options.Find().SetSkip(int64(skip)).SetLimit(int64(limit))
+
+	filter := primitive.M{"collaborators": primitive.M{"$in": []primitive.ObjectID{userID}}}
+
+	cursor, err := s.db.Database("storyhub").Collection("storydetails").Find(ctx, filter, findOptions)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching stories: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var stories []data.StoryDetails
+	if err := cursor.All(ctx, &stories); err != nil {
+		return nil, fmt.Errorf("error decoding stories: %v", err)
+	}
+
 	return stories, nil
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -43,6 +43,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e.GET("/api/v1/get-story-collaborators/", s.GetStoryCollaborators)
 	e.GET("/api/v1/get-stories-by-filters", s.GetStoriesByFilter)
 	e.POST("/api/v1/get-stories-by-user", s.GetStoriesByUser)
+	e.GET("/api/v1/collaborations", s.GetCollaborations, s.JWTMiddleware())
 	// e.PUT("/api/v1/update", s.Update, s.JWTMiddleware())
 	// e.PATCH("/api/v1/update", s.Update, s.JWTMiddleware())
 	// e.DELETE("/api/v1/delete", s.Delete, s.JWTMiddleware())
@@ -218,6 +219,22 @@ func (s *Server) GetStoriesByUser(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}
 	return c.JSON(http.StatusOK, map[string]any{"message": "Stories found", "stories": stories})
+}
+
+func (s *Server) GetCollaborations(c echo.Context) error {
+	var request struct {
+		Page  int `json:"page"`
+		Limit int `json:"limit"`
+	}
+	if err := c.Bind(&request); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
+	}
+	userID := c.Get("user_id").(primitive.ObjectID)
+	collaborations, err := s.db.GetCollaborations(userID, request.Page, request.Limit)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
+	}
+	return c.JSON(http.StatusOK, map[string]any{"message": "Collaborations found", "collaborations": collaborations})
 }
 
 func (s *Server) JWTMiddleware() echo.MiddlewareFunc {


### PR DESCRIPTION
### TL;DR

Added functionality to retrieve stories where a user is a collaborator.

### What changed?

- Added a new `GetCollaborations` method to the database service interface and implemented it
- Added a new API endpoint `/api/v1/collaborations` that uses JWT authentication to fetch stories where the authenticated user is a collaborator
- The endpoint supports pagination through page and limit parameters

### How to test?

1. Authenticate a user to get a JWT token
2. Make a GET request to `/api/v1/collaborations` with the JWT token in the Authorization header
3. Include page and limit parameters in the request body
4. Verify that the response contains stories where the user is listed as a collaborator

### Why make this change?

This change enables users to view all stories they're collaborating on, separate from stories they've created themselves. This is an important feature for collaborative storytelling, allowing users to easily find and continue working on stories where they've been invited as collaborators.