### PR TITLE
get-stories needs to be POST not GET

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -39,7 +39,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e.POST("/api/v1/create-story", s.CreateStory, s.JWTMiddleware())
 	e.GET("/api/v1/get-story-details/", s.GetStoryDetails)
 	e.GET("/api/v1/get-story-content/", s.GetStoryContent)
-	e.GET("/api/v1/get-stories", s.GetStories)
+	e.POST("/api/v1/get-stories", s.GetStories)
 	e.GET("/api/v1/get-story-collaborators/", s.GetStoryCollaborators)
 	e.GET("/api/v1/get-stories-by-filters", s.GetStoriesByFilter)
 	e.POST("/api/v1/get-stories-by-user", s.GetStoriesByUser)


### PR DESCRIPTION
### TL;DR

Changed the `/api/v1/get-stories` endpoint from GET to POST method.

### What changed?

Modified the HTTP method for the `/api/v1/get-stories` endpoint from GET to POST in the route registration. This allows the endpoint to accept request body data instead of only query parameters.

### How to test?

1. Update any client code that calls this endpoint to use POST instead of GET
2. Verify that requests to `/api/v1/get-stories` using POST method return the expected response
3. Confirm that GET requests to this endpoint now fail with an appropriate error

### Why make this change?

Switching to POST allows for sending more complex query parameters in the request body rather than being limited to URL query parameters. This provides more flexibility for filtering or pagination options when retrieving stories, especially when dealing with potentially large parameter sets that would be unwieldy in a URL.