### PR TITLE
stories by filter can now take genres array

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -23,7 +23,7 @@ type Service interface {
 	GetStoryContent(id primitive.ObjectID) (*data.StoryContent, error)
 	GetStories(page, limit int) ([]data.StoryDetails, error)
 	GetStoryCollaborators(id primitive.ObjectID) ([]data.Collaborator, error)
-	GetStoriesByFilters(genre string, page, limit int) ([]data.StoryDetails, error)
+	GetStoriesByFilters(genres []string, page, limit int) ([]data.StoryDetails, error)
 	GetStoriesByUser(userID primitive.ObjectID, page, limit int) ([]data.StoryDetails, error)
 	GetCollaborations(userID primitive.ObjectID, page, limit int) ([]data.StoryDetails, error)
 	ValidateToken(authHeader string) (primitive.ObjectID, error)
@@ -137,13 +137,13 @@ func (s *service) GetStoryCollaborators(id primitive.ObjectID) ([]data.Collabora
 	return collaborators, nil
 }
 
-func (s *service) GetStoriesByFilters(genre string, page, limit int) ([]data.StoryDetails, error) {
+func (s *service) GetStoriesByFilters(genres []string, page, limit int) ([]data.StoryDetails, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	filter := primitive.M{}
-	if genre != "" {
-		filter["genre"] = genre
+	if len(genres) > 0 {
+		filter["genre"] = primitive.M{"$in": genres}
 	}
 
 	skip := (page - 1) * limit

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -187,14 +187,14 @@ func (s *Server) GetStoryCollaborators(c echo.Context) error {
 
 func (s *Server) GetStoriesByFilter(c echo.Context) error {
 	var request struct {
-		Genre string `json:"genre"`
-		Page  int    `json:"page"`
-		Limit int    `json:"limit"`
+		Genres []string `json:"genres"`
+		Page   int      `json:"page"`
+		Limit  int      `json:"limit"`
 	}
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
 	}
-	stories, err := s.db.GetStoriesByFilters(request.Genre, request.Page, request.Limit)
+	stories, err := s.db.GetStoriesByFilters(request.Genres, request.Page, request.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}


### PR DESCRIPTION
### TL;DR

Enhanced story filtering to support multiple genres instead of a single genre.

### What changed?

- Modified the `GetStoriesByFilters` function to accept an array of genres instead of a single genre string
- Updated the database query to use MongoDB's `$in` operator to filter stories by multiple genres
- Updated the request structure in the `GetStoriesByFilter` API endpoint to accept an array of genres

### How to test?

1. Send a POST request to the stories filter endpoint with multiple genres:
   ```json
   {
     "genres": ["Fantasy", "Sci-Fi"],
     "page": 1,
     "limit": 10
   }
   ```
2. Verify that stories from any of the specified genres are returned in the response
3. Test with an empty genres array to ensure all stories are returned
4. Test with a single genre to ensure backward compatibility

### Why make this change?

This change improves the user experience by allowing more flexible story filtering. Users can now search for stories across multiple genres simultaneously rather than being limited to a single genre, making content discovery more efficient and versatile.