### PR TITLE
fixed getting story details, collaborators and content

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -23,13 +23,6 @@ type StoryContent struct {
 	Content string             `json:"content" bson:"content" validate:"required,min=20"`
 }
 
-type Collaborator struct {
-	ID      primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	StoryID primitive.ObjectID `json:"story_id" bson:"story_id" validate:"required"`
-	UserID  primitive.ObjectID `json:"user_id" bson:"user_id" validate:"required"`
-	Role    string             `json:"role" bson:"role" validate:"required,oneof=editor viewer"`
-}
-
 type ForkRequest struct {
 	StoryID primitive.ObjectID `json:"story_id" validate:"required"`
 	UserID  primitive.ObjectID `json:"user_id" validate:"required"`


### PR DESCRIPTION
### TL;DR

Simplified collaborator management by removing the dedicated Collaborator type and updating related endpoints.

### What changed?

- Removed the `Collaborator` struct from `schemas.go` as it's no longer needed
- Modified `GetStoryCollaborators` to return an array of ObjectIDs instead of Collaborator objects
- Updated the implementation to fetch collaborators directly from the StoryDetails document
- Changed HTTP methods for several endpoints:
  - `/api/v1/get-story-details` from GET to POST
  - Fixed trailing slashes in route definitions
- Enhanced response formats:
  - Added a structured response for `GetStoryCollaborators` with a message and collaborators array
  - Improved `GetStoryDetails` response to include a success message

### How to test?

1. Test the updated `/api/v1/get-story-collaborators` endpoint with a valid story ID
2. Verify the endpoint returns an array of collaborator IDs instead of full Collaborator objects
3. Test the modified `/api/v1/get-story-details` endpoint using POST method
4. Confirm the response format includes both a message and the story details

### Why make this change?

This change simplifies the data model by eliminating redundant storage of collaborator information. Instead of maintaining a separate collection for collaborators, we now store and retrieve this information directly from the StoryDetails document. This approach reduces database complexity and improves query efficiency by eliminating the need for additional database operations.