### PR TITLE
plz be fixed

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -88,10 +88,16 @@ func (s *service) GetStoryContent(id primitive.ObjectID) (*data.StoryContent, er
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	var content data.StoryContent
-	err := s.db.Database("storyhub").Collection("storycontent").FindOne(ctx, primitive.M{"story_id": id}).Decode(&content)
+	var story data.StoryDetails
+	err := s.db.Database("storyhub").Collection("storydetails").FindOne(ctx, primitive.M{"_id": id}).Decode(&story)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching story content: %v", err)
+		return nil, fmt.Errorf("story not found")
+	}
+
+	var content data.StoryContent
+	err = s.db.Database("storyhub").Collection("storycontent").FindOne(ctx, primitive.M{"story_id": id}).Decode(&content)
+	if err != nil {
+		return &data.StoryContent{StoryID: id}, nil
 	}
 
 	return &content, nil
@@ -125,9 +131,6 @@ func (s *service) GetStoryCollaborators(id primitive.ObjectID) ([]primitive.Obje
 	err := s.db.Database("storyhub").Collection("storydetails").FindOne(ctx, primitive.M{"_id": id}).Decode(&story)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching story: %v", err)
-	}
-	if len(story.Collaborators) == 0 {
-		return nil, fmt.Errorf("No collaborators found")
 	}
 	return story.Collaborators, nil
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -188,15 +188,7 @@ func (s *Server) GetStoryCollaborators(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}
 
-	var response struct {
-		Message       string               `json:"message"`
-		Collaborators []primitive.ObjectID `json:"collaborators"`
-	}
-
-	response.Message = "Collaborators fetched successfully"
-	response.Collaborators = collaborators
-
-	return c.JSON(http.StatusOK, response)
+	return c.JSON(http.StatusOK, map[string]any{"message": "Collaborators found", "collaborators": collaborators})
 }
 
 func (s *Server) GetStoriesByFilters(c echo.Context) error {


### PR DESCRIPTION
### TL;DR

Improved error handling for story content and collaborators endpoints.

### What changed?

- Modified `GetStoryContent` to first verify the story exists before fetching content
- Changed error handling to return an empty content object when no content exists instead of an error
- Removed the error when no collaborators are found in `GetStoryCollaborators`
- Simplified the response structure in the `GetStoryCollaborators` endpoint

### How to test?

1. Try fetching content for a story that exists but has no content - should return an empty content object
2. Try fetching collaborators for a story with no collaborators - should return an empty array instead of an error
3. Verify the response format for the collaborators endpoint matches the new structure

### Why make this change?

These changes improve the API's robustness by handling edge cases more gracefully. Empty content or collaborator lists are valid states rather than error conditions. The code now properly distinguishes between "resource not found" errors and valid empty states, providing a more consistent experience for frontend applications.