### PR TITLE
fixed request json

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -117,7 +117,7 @@ func (s *Server) CreateStory(c echo.Context) error {
 
 func (s *Server) GetStoryDetails(c echo.Context) error {
 	var request struct {
-		ID string `json:"id"`
+		ID string `json:"story_id"`
 	}
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
@@ -135,7 +135,7 @@ func (s *Server) GetStoryDetails(c echo.Context) error {
 
 func (s *Server) GetStoryContent(c echo.Context) error {
 	var request struct {
-		ID string `json:"id"`
+		ID string `json:"story_id"`
 	}
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
@@ -168,7 +168,7 @@ func (s *Server) GetStories(c echo.Context) error {
 
 func (s *Server) GetStoryCollaborators(c echo.Context) error {
 	var request struct {
-		ID string `json:"id"`
+		ID string `json:"story_id"`
 	}
 
 	if err := c.Bind(&request); err != nil {


### PR DESCRIPTION
### TL;DR

Updated JSON field name from `id` to `story_id` in story-related API endpoints.

### What changed?

Changed the JSON field name in request structs from `id` to `story_id` in three endpoints:
- `GetStoryDetails`
- `GetStoryContent`
- `GetStoryCollaborators`

This makes the API more consistent and explicit about what type of ID is being requested.

### Why make this change?

This change improves API clarity and consistency by using a more descriptive field name. Using `story_id` instead of the generic `id` makes it clearer what type of identifier is expected, reducing potential confusion for API consumers and making the codebase more maintainable.