### PR TITLE
fixed http request methods

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64
 
       - name: Run gofmt
         run: |


### PR DESCRIPTION
### TL;DR

Converted several POST endpoints to more RESTful GET and DELETE endpoints with URL parameters.

### What changed?

- Changed the following endpoints from POST to GET with URL parameters:
  - `/api/v1/get-story-details` → `/api/v1/get-story-details/:story_id`
  - `/api/v1/get-story-content` → `/api/v1/get-story-content/:story_id`
  - `/api/v1/get-story-collaborators` → `/api/v1/get-story-collaborators/:story_id`
- Changed DELETE endpoint to use URL parameter:
  - `/api/v1/delete-story` → `/api/v1/delete-story/:story_id`
- Removed request body parsing in favor of URL parameter extraction
- Updated the corresponding handler functions to use `c.Param("story_id")` instead of parsing request bodies

### Why make this change?

This change follows RESTful API design principles by using HTTP methods appropriately and placing resource identifiers in the URL path rather than in the request body. This improves API usability, makes endpoints more intuitive, and enables better caching for GET requests.