### PR TITLE
fixed linting issue in middleware jwt

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type StoryDetails struct {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -307,24 +307,32 @@ func (s *Server) JWTMiddleware() echo.MiddlewareFunc {
 		SuccessHandler: func(c echo.Context) {
 			token, ok := c.Get("user").(*jwt.Token)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			claims, ok := token.Claims.(*jwt.RegisteredClaims)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			if claims.ID != "access" {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			userID, err := primitive.ObjectIDFromHex(claims.Subject)
 			if err != nil {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 


### PR DESCRIPTION
### TL;DR

Added error logging for JSON response failures in JWT middleware.

### What changed?

Enhanced the JWT middleware's `SuccessHandler` function to properly handle and log errors that might occur when sending JSON responses. Previously, the function was calling `c.JSON()` without checking for errors, which could lead to silent failures. Now, each JSON response is wrapped in an error check that logs any failures to the Echo logger.

### Why make this change?

This change improves error observability in the authentication flow. Without proper error logging, issues with sending JSON responses to clients could go unnoticed, making debugging more difficult. This enhancement follows best practices for error handling and ensures that any problems with response generation are properly captured in logs.