### PR TITLE
fixed jwtsecret env var names

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -62,7 +62,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 var (
 	debug     = os.Getenv("DEBUG") == "true"
-	jwtSecret = []byte(os.Getenv("JWT_SECRET"))
+	jwtSecret = []byte(os.Getenv("JWTSECRET"))
 )
 
 func DEBUG(e *echo.Echo) {


### PR DESCRIPTION
### TL;DR

Updated the environment variable name for JWT secret from `JWT_SECRET` to `JWTSECRET`.

### What changed?

Modified the environment variable reference in `internal/server/routes.go` to use `JWTSECRET` instead of the previous `JWT_SECRET` when initializing the JWT secret byte array.

### Why make this change?

This change standardizes our environment variable naming convention by removing the underscore. This makes the variable name consistent with other environment variables in the system and prevents potential configuration issues across different environments.