### PR TITLE
return story_id after creating the story

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Service interface {
-	CreateStory(req *data.StoryDetails) (bool, error)
+	CreateStory(req *data.StoryDetails) (primitive.ObjectID, error)
 	GetStoryDetails(id primitive.ObjectID) (*data.StoryDetails, error)
 	GetStoryContent(id primitive.ObjectID) (*data.StoryContent, error)
 	GetStories(page, limit int) ([]data.StoryDetails, error)
@@ -51,7 +51,7 @@ func New() Service {
 	}
 }
 
-func (s *service) CreateStory(req *data.StoryDetails) (bool, error) {
+func (s *service) CreateStory(req *data.StoryDetails) (primitive.ObjectID, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -60,11 +60,10 @@ func (s *service) CreateStory(req *data.StoryDetails) (bool, error) {
 
 	res, err := s.db.Database("storyhub").Collection("storydetails").InsertOne(ctx, req)
 	if err != nil {
-		return false, fmt.Errorf("error inserting story: %v", err)
+		return primitive.NilObjectID, fmt.Errorf("error inserting story: %v", err)
 	}
 
-	req.ID = res.InsertedID.(primitive.ObjectID)
-	return true, nil
+	return res.InsertedID.(primitive.ObjectID), nil
 }
 
 func (s *service) GetStoryDetails(id primitive.ObjectID) (*data.StoryDetails, error) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -106,18 +106,21 @@ func DEBUG(e *echo.Echo) {
 func (s *Server) CreateStory(c echo.Context) error {
 	var story data.StoryDetails
 	story.OwnerID = c.Get("user_id").(primitive.ObjectID)
+
 	if err := c.Bind(&story); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
 	}
-	created, err := s.db.CreateStory(&story)
+
+	insertedID, err := s.db.CreateStory(&story)
 	if err != nil {
 		c.Logger().Error(err.Error())
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}
-	if !created {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Failed to create story"})
-	}
-	return c.JSON(http.StatusCreated, map[string]string{"message": "Story created successfully"})
+
+	return c.JSON(http.StatusCreated, map[string]any{
+		"message":  "Story created successfully",
+		"story_id": insertedID,
+	})
 }
 
 func (s *Server) GetStoryDetails(c echo.Context) error {


### PR DESCRIPTION
### TL;DR

Improved the `CreateStory` function to return the created story's ID to the client.

### What changed?

- Modified the `CreateStory` method signature in the database service interface to return a `primitive.ObjectID` instead of a boolean
- Updated the implementation to return the inserted ID directly instead of modifying the request object
- Enhanced the API response in the server handler to include the newly created story's ID in the JSON response

### Why make this change?

This change improves the API usability by providing clients with the ID of the newly created story in the response. This allows clients to immediately reference or navigate to the new story without having to make additional queries to find it.