### PR TITLE
logging for editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Simple Makefile for a Go project
 
 # Build the application
-all: build test
+all: build
 
 build:
 	@echo "Building..."

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -24,6 +26,22 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
+	// Debug middleware to log request bodies
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if debug {
+				body, err := io.ReadAll(c.Request().Body)
+				if err != nil {
+					log.Printf("Error reading request body: %v", err)
+				} else {
+					log.Printf("Request Body: %s", string(body))
+					c.Request().Body = io.NopCloser(bytes.NewBuffer(body))
+				}
+			}
+			return next(c)
+		}
+	})
+
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins:     []string{"https://*", "http://*"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
@@ -32,7 +50,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 		MaxAge:           300,
 	}))
 
-	e.Logger.SetLevel(log.INFO)
+	e.Logger.SetLevel(log.Lvl(log.INFO))
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: "method=${method}, uri=${uri}, status=${status}\n",
 	}))
@@ -230,13 +248,43 @@ func (s *Server) GetCollaborations(c echo.Context) error {
 }
 
 func (s *Server) EditStory(c echo.Context) error {
+	// Read raw body first
+	bodyBytes, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		log.Infof("Error reading request body: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Could not read request body"})
+	}
+
+	// Log raw body for debugging
+	log.Infof("Raw request body: %s", string(bodyBytes))
+
+	// Restore body for further processing
+	c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
 	var updatedStory struct {
 		ID      string `json:"story_id"`
 		Content string `json:"content"`
 	}
-	if err := c.Bind(&updatedStory); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid request body"})
+
+	// Try to unmarshal manually first
+	var rawMap map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &rawMap); err != nil {
+		log.Infof("JSON unmarshal error for raw map: %v", err)
+	} else {
+		log.Infof("Parsed raw map: %+v", rawMap)
 	}
+
+	// Attempt binding
+	if err := c.Bind(&updatedStory); err != nil {
+		log.Infof("Bind error: %v", err)
+		log.Infof("Bind error details: story_id=%s, content length=%d", updatedStory.ID, len(updatedStory.Content))
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"message":  "Invalid request body",
+			"error":    err.Error(),
+			"raw_body": string(bodyBytes),
+		})
+	}
+
 	storyId, err := primitive.ObjectIDFromHex(updatedStory.ID)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"message": "Invalid story ID"})


### PR DESCRIPTION
### TL;DR

Added request body debugging capabilities and fixed the `EditStory` endpoint to better handle and troubleshoot request parsing issues.

### What changed?

- Modified the Makefile to only build without running tests by default
- Added a debug middleware to log request bodies
- Enhanced the `EditStory` endpoint with improved error handling and request body logging
- Fixed Echo logger level setting syntax
- Added manual JSON parsing diagnostics to help troubleshoot binding issues

### Why make this change?

There were likely issues with the `EditStory` endpoint not properly parsing request bodies, making it difficult to diagnose problems. These changes add comprehensive logging and error reporting to help identify and fix request parsing issues, particularly with the story content and ID fields.