### PR TITLE
added forking

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -15,7 +15,7 @@ type StoryDetails struct {
 	Collaborators []primitive.ObjectID `json:"collaborators,omitempty" bson:"collaborators,omitempty"`
 	CreatedAt     time.Time            `json:"created_at" bson:"created_at"`
 	UpdatedAt     time.Time            `json:"updated_at" bson:"updated_at"`
-	ForkedFrom    *primitive.ObjectID  `json:"forked_from,omitempty" bson:"forked_from,omitempty"`
+	ForkedFrom    primitive.ObjectID   `json:"forked_from,omitempty" bson:"forked_from,omitempty"`
 }
 
 type StoryContent struct {


### PR DESCRIPTION
### TL;DR

Added story forking functionality to allow users to create copies of existing stories.

### What changed?

- Modified `StoryDetails` struct to change `ForkedFrom` from a pointer to a direct `primitive.ObjectID`
- Added a new `ForkStory` method to the database service interface and implemented it
- Improved error handling in `GetStoryContent` to properly handle missing content
- Added a new API endpoint `/api/v1/fork-story/:story_id` with JWT authentication
- Implemented the handler function to prevent users from forking their own stories

### Why make this change?

This feature allows users to create their own versions of existing stories, enabling collaborative storytelling and creative remixing while maintaining attribution to the original author. Forking is a common feature in creative platforms that encourages content reuse and adaptation while preserving the connection to source material.