### PR TITLE
dunno

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -291,6 +291,9 @@ func (s *Server) ForkStory(c echo.Context) error {
 	}
 	forkedStoryID, err := s.db.ForkStory(storyId, userId)
 	if err != nil {
+		if strings.Contains(err.Error(), "you have already forked this story") {
+			return c.JSON(http.StatusConflict, map[string]string{"message": "You have already forked this story"})
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}
 	if forkedStoryID == primitive.NilObjectID {


### PR DESCRIPTION
### TL;DR

Prevent users from forking the same story multiple times.

### What changed?

- Added a check in the `ForkStory` function to verify if a user has already forked a particular story
- Added error handling in the server route to return a 409 Conflict status when a user attempts to fork a story they've already forked
- Imported the `bson` package to support the query for existing forks

### Why make this change?

This change prevents duplicate forks in the database and provides a better user experience by clearly indicating when a story has already been forked by the user. It maintains data integrity by ensuring each user can only have one fork of a particular story.