### PR TITLE
CleanupOrphanedStories added auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/mAmineChniti/StoryHub
 
 go 1.24.0
+
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
### TL;DR

Added JWT authentication to the CleanupOrphanedStories function to secure API requests.

### What changed?

- Added the `github.com/golang-jwt/jwt/v5` package as a dependency
- Implemented JWT token generation in the `CleanupOrphanedStories` function
- Added an Authorization header with the JWT token to the HTTP request
- Set a short expiration time (5 minutes) for the system-generated token
- Reorganized imports for better readability

### Why make this change?

This change enhances security by ensuring that the cleanup process, which may delete data, can only be executed with proper authentication. Using a system-generated JWT token prevents unauthorized access to the cleanup endpoint and follows security best practices for internal API communication.